### PR TITLE
Implement basic MLP encoder

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,3 @@
+from .models import MLPEncoder
+
+__all__ = ["MLPEncoder"]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,3 @@
+from .mlp import MLPEncoder
+
+__all__ = ["MLPEncoder"]

--- a/src/models/mlp.py
+++ b/src/models/mlp.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class MLPEncoder(nn.Module):
+    """Simple MLP encoder with outcome and tau heads."""
+
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, 256),
+            nn.LayerNorm(256),
+            nn.GELU(),
+            nn.Linear(256, 128),
+            nn.LayerNorm(128),
+            nn.GELU(),
+            nn.Linear(128, 64),
+            nn.LayerNorm(64),
+            nn.GELU(),
+        )
+        self.outcome_head = nn.Linear(64, 1)
+        self.tau_head = nn.Linear(64, 1)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        feats = self.net(x)
+        outcome = self.outcome_head(feats).squeeze(-1)
+        tau = self.tau_head(feats).squeeze(-1)
+        return outcome, tau
+
+
+__all__ = ["MLPEncoder"]

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src import MLPEncoder
+import torch
+
+
+def test_mlp_encoder_shapes() -> None:
+    batch_size = 4
+    input_dim = 10
+    model = MLPEncoder(input_dim)
+    x = torch.randn(batch_size, input_dim)
+    outcome, tau = model(x)
+    assert outcome.shape == (batch_size,)
+    assert tau.shape == (batch_size,)


### PR DESCRIPTION
## Summary
- add an MLP encoder module using the recommended 256→128→64 layers
- expose `MLPEncoder` via the package init
- test that the encoder outputs the expected shapes

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68625e97c6c08324aaeac5cc22d5ea08