### PR TITLE
Implement IHDP dataset loader with deterministic splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ Refer to `Prompt.md` for the full research notes.
 
 This repository currently contains a minimal project skeleton. Code lives under
 `src/`, configurations under `configs/`, and tests under `tests/`.
+
+## Dataset loaders
+
+`load_ihdp()` downloads the public IHDP benchmark and returns deterministic
+train/val/test splits. By default data are cached under `~/.cache/otxlearner/ihdp`.

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,3 @@
+from .ihdp import IHDPDataset, IHDPSplit, load_ihdp
+
+__all__ = ["IHDPDataset", "IHDPSplit", "load_ihdp"]

--- a/src/data/ihdp.py
+++ b/src/data/ihdp.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+__all__ = ["IHDPSplit", "IHDPDataset", "load_ihdp"]
+
+URL_TRAIN = "https://www.fredjo.com/files/ihdp_npci_1-100.train.npz"
+URL_TEST = "https://www.fredjo.com/files/ihdp_npci_1-100.test.npz"
+
+
+@dataclass
+class IHDPSplit:
+    x: np.ndarray
+    t: np.ndarray
+    yf: np.ndarray
+    ycf: np.ndarray
+    mu0: np.ndarray
+    mu1: np.ndarray
+
+
+@dataclass
+class IHDPDataset:
+    train: IHDPSplit
+    val: IHDPSplit
+    test: IHDPSplit
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        return
+    with urllib.request.urlopen(url) as resp:
+        dest.write_bytes(resp.read())
+
+
+def _load_npz(path: Path) -> dict[str, np.ndarray]:
+    data = np.load(path, allow_pickle=False)
+    return {k: data[k] for k in data.files}
+
+
+def _flatten(features: np.ndarray) -> np.ndarray:
+    if features.ndim == 3:  # (n, d, r)
+        n, d, r = features.shape
+        return np.asarray(features.transpose(2, 0, 1).reshape(n * r, d))
+    if features.ndim == 2:  # (n, r)
+        n, r = features.shape
+        return np.asarray(features.T.reshape(n * r))
+    raise ValueError(f"Unexpected shape {features.shape}")
+
+
+def load_ihdp(
+    root: str | Path = Path.home() / ".cache" / "otxlearner" / "ihdp",
+    *,
+    val_fraction: float = 0.1,
+    seed: int = 42,
+) -> IHDPDataset:
+    """Load IHDP with deterministic train/val/test splits."""
+    root = Path(root)
+    train_path = root / "ihdp_npci_1-100.train.npz"
+    test_path = root / "ihdp_npci_1-100.test.npz"
+    _download(URL_TRAIN, train_path)
+    _download(URL_TEST, test_path)
+
+    train_npz = _load_npz(train_path)
+    test_npz = _load_npz(test_path)
+
+    x_train = _flatten(train_npz["x"])
+    t_train = _flatten(train_npz["t"])
+    yf_train = _flatten(train_npz["yf"])
+    ycf_train = _flatten(train_npz["ycf"])
+    mu0_train = _flatten(train_npz["mu0"])
+    mu1_train = _flatten(train_npz["mu1"])
+
+    x_test = _flatten(test_npz["x"])
+    t_test = _flatten(test_npz["t"])
+    yf_test = _flatten(test_npz["yf"])
+    ycf_test = _flatten(test_npz["ycf"])
+    mu0_test = _flatten(test_npz["mu0"])
+    mu1_test = _flatten(test_npz["mu1"])
+
+    rng = np.random.default_rng(seed)
+    idx = np.arange(x_train.shape[0])
+    rng.shuffle(idx)
+    val_size = int(len(idx) * val_fraction)
+    val_idx = idx[:val_size]
+    train_idx = idx[val_size:]
+
+    def split(idx: np.ndarray) -> IHDPSplit:
+        return IHDPSplit(
+            x=x_train[idx],
+            t=t_train[idx],
+            yf=yf_train[idx],
+            ycf=ycf_train[idx],
+            mu0=mu0_train[idx],
+            mu1=mu1_train[idx],
+        )
+
+    train = split(train_idx)
+    val = split(val_idx)
+    test = IHDPSplit(x_test, t_test, yf_test, ycf_test, mu0_test, mu1_test)
+
+    return IHDPDataset(train=train, val=val, test=test)

--- a/tests/test_ihdp_loader.py
+++ b/tests/test_ihdp_loader.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.data import load_ihdp
+
+
+def test_ihdp_deterministic(tmp_path) -> None:
+    ds1 = load_ihdp(tmp_path, val_fraction=0.2, seed=0)
+    ds2 = load_ihdp(tmp_path, val_fraction=0.2, seed=0)
+    assert np.array_equal(ds1.train.x, ds2.train.x)
+    assert np.array_equal(ds1.val.x, ds2.val.x)
+
+
+def test_ihdp_split_sizes(tmp_path) -> None:
+    ds = load_ihdp(tmp_path, val_fraction=0.1, seed=1)
+    n_total = 67200
+    assert ds.train.x.shape[0] + ds.val.x.shape[0] == n_total
+    assert ds.test.x.shape[0] == 7500


### PR DESCRIPTION
## Summary
- add IHDP dataset downloader/loader returning deterministic train/val/test splits
- expose loader via `src.data`
- document the loader in the README
- add unit tests for deterministic splits and sizes

## Testing
- `ruff check src tests`
- `mypy --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625e78dd548324a38e29b58e53c7f4