### PR TITLE
Add Sinkhorn layer

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .sinkhorn import Sinkhorn
+
+__all__ = ["Sinkhorn"]

--- a/src/models/sinkhorn.py
+++ b/src/models/sinkhorn.py
@@ -1,0 +1,25 @@
+"""Sinkhorn layer."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+from geomloss import SamplesLoss
+
+
+class Sinkhorn(torch.nn.Module):
+    """Compute Sinkhorn divergence between two point clouds."""
+
+    def __init__(self, *, blur: float = 0.05, p: int = 2) -> None:
+        super().__init__()
+        self.blur = blur
+        self.p = p
+        self.loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] = (
+            SamplesLoss(loss="sinkhorn", p=self.p, blur=self.blur)
+        )
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        if x.ndim != 2 or y.ndim != 2:
+            raise ValueError("Inputs must be 2D matrices")
+        return self.loss_fn(x, y)

--- a/tests/test_sinkhorn.py
+++ b/tests/test_sinkhorn.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+import torch
+
+from src.models.sinkhorn import Sinkhorn
+
+
+def test_sinkhorn_forward_shape() -> None:
+    layer = Sinkhorn(blur=0.1, p=2)
+    x = torch.randn(5, 3, requires_grad=True)
+    y = torch.randn(6, 3, requires_grad=True)
+    loss = layer(x, y)
+    assert loss.dim() == 0
+
+
+def test_sinkhorn_backward() -> None:
+    layer = Sinkhorn()
+    x = torch.randn(4, 2, requires_grad=True)
+    y = torch.randn(4, 2, requires_grad=True)
+    loss = layer(x, y)
+    loss.backward()
+    assert x.grad is not None and y.grad is not None


### PR DESCRIPTION
## Summary
- implement configurable Sinkhorn layer using geomloss
- expose Sinkhorn via models package
- unit test for shapes and gradients

## Testing
- `ruff check src tests`
- `black src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625e86cbe88324836c9d165cb4c245