### PR TITLE
Add evaluation pipeline and metrics utilities

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,10 +1,128 @@
-"""Evaluation script placeholder."""
+"""Evaluate a trained model on IHDP."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+from .data import load_ihdp
+from .models import MLPEncoder, Sinkhorn
+from .train import torchify
+from .utils import ate, pehe
 
 
-def main() -> None:
-    """Entry point for evaluation."""
-    raise NotImplementedError("Evaluation loop not implemented yet.")
+def evaluate(
+    data_root: str | Path,
+    model_path: str | Path,
+    *,
+    batch_size: int = 512,
+    epsilon: float = 0.05,
+    device: str | torch.device = "cpu",
+    csv_path: str | Path | None = None,
+    plot_file: str | Path | None = None,
+) -> dict[str, float]:
+    """Run evaluation on the IHDP test split."""
+
+    device = torch.device(device)
+    ds_np = load_ihdp(data_root)
+    ds = torchify(ds_np)
+    loader = DataLoader(ds.test, batch_size=batch_size)
+
+    model = MLPEncoder(ds.test.x.shape[1]).to(device)
+    state = torch.load(model_path, map_location=device)
+    model.load_state_dict(state)
+
+    sinkhorn = Sinkhorn(blur=epsilon).to(device)
+
+    model.eval()
+    tau_err = 0.0
+    bal = 0.0
+    tau_preds: list[torch.Tensor] = []
+    tau_targets: list[torch.Tensor] = []
+    with torch.no_grad():
+        for x, t, _yf, mu0, mu1 in loader:
+            x, t, mu0, mu1 = (
+                x.to(device),
+                t.to(device),
+                mu0.to(device),
+                mu1.to(device),
+            )
+            tau_true = mu1 - mu0
+            feats = model.net(x)
+            tau = model.tau_head(feats).squeeze(-1)
+            tau_err += nn.functional.mse_loss(tau, tau_true, reduction="sum").item()
+            feats_t = feats[t.bool()]
+            feats_c = feats[~t.bool()]
+            if len(feats_t) > 0 and len(feats_c) > 0:
+                bal += sinkhorn(feats_t, feats_c).item() * x.size(0)
+            tau_preds.append(tau.cpu())
+            tau_targets.append(tau_true.cpu())
+
+    mse = tau_err / len(ds.test)
+    bal /= len(ds.test)
+    tau_pred = torch.cat(tau_preds)
+    tau_true = torch.cat(tau_targets)
+    metrics = {
+        "mse": mse,
+        "balance": bal,
+        "pehe": pehe(tau_pred, tau_true),
+        "ate_error": ate(tau_pred, tau_true),
+    }
+
+    if csv_path is not None:
+        csv_path = Path(csv_path)
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        with csv_path.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=list(metrics.keys()))
+            writer.writeheader()
+            writer.writerow(metrics)
+
+    if plot_file is not None:
+        try:
+            import matplotlib.pyplot as plt  # type: ignore
+        except Exception:
+            plt = None
+        if plt is not None:
+            tau_p = tau_pred.numpy()
+            tau_t = tau_true.numpy()
+            Path(plot_file).parent.mkdir(parents=True, exist_ok=True)
+            plt.figure()
+            plt.scatter(tau_t, tau_p, s=5, alpha=0.5)
+            plt.xlabel("True τ")
+            plt.ylabel("Predicted τ")
+            plt.tight_layout()
+            plt.savefig(plot_file)
+            plt.close()
+
+    return metrics
 
 
-if __name__ == "__main__":
+def main() -> None:  # pragma: no cover - CLI wrapper
+    parser = argparse.ArgumentParser(description="Evaluate IHDP model")
+    parser.add_argument("model", type=Path, help="Path to .pt checkpoint")
+    parser.add_argument(
+        "--data-root", type=Path, default=Path.home() / ".cache/otxlearner/ihdp"
+    )
+    parser.add_argument("--batch-size", type=int, default=512)
+    parser.add_argument("--epsilon", type=float, default=0.05)
+    parser.add_argument("--csv", type=Path, default=None)
+    parser.add_argument("--plot", type=Path, default=None)
+    args = parser.parse_args()
+
+    evaluate(
+        args.data_root,
+        args.model,
+        batch_size=args.batch_size,
+        epsilon=args.epsilon,
+        csv_path=args.csv,
+        plot_file=args.plot,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
     main()

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,3 @@
+from .metrics import ate, pehe
+
+__all__ = ["pehe", "ate"]

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import torch
+
+
+def pehe(tau_pred: torch.Tensor, tau_true: torch.Tensor) -> float:
+    """Return Precision in Estimation of Heterogeneous Effect."""
+    return float(torch.sqrt(torch.mean((tau_pred - tau_true) ** 2)).item())
+
+
+def ate(tau_pred: torch.Tensor, tau_true: torch.Tensor) -> float:
+    """Return Average Treatment Effect error."""
+    return float(tau_pred.mean().item() - tau_true.mean().item())
+
+
+__all__ = ["pehe", "ate"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.utils.metrics import ate, pehe
+
+
+def test_pehe() -> None:
+    pred = torch.tensor([1.0, 2.0, 3.0])
+    true = torch.tensor([1.0, 1.0, 1.0])
+    expected = torch.sqrt(torch.mean((pred - true) ** 2)).item()
+    assert abs(pehe(pred, true) - expected) < 1e-6
+
+
+def test_ate() -> None:
+    pred = torch.tensor([0.0, 2.0, 4.0])
+    true = torch.tensor([0.0, 1.0, 3.0])
+    expected = pred.mean().item() - true.mean().item()
+    assert abs(ate(pred, true) - expected) < 1e-6


### PR DESCRIPTION
## Summary
- implement PEHE and ATE metric helpers
- expose helpers via utils package
- write evaluation script with CSV output and optional plotting
- add unit tests for metric helpers

## Testing
- `ruff check src tests`
- `black src tests --check`
- `mypy --strict src` *(fails: process stalled)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686277ad194c83248b5af081a17da1a6