### PR TITLE
Add Twins dataset loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ This repository currently contains a minimal project skeleton. Code lives under
 
 `load_ihdp()` downloads the public IHDP benchmark and returns deterministic
 train/val/test splits. By default data are cached under `~/.cache/otxlearner/ihdp`.
+
+`load_twins()` expects a `twins.npz` archive with arrays `x`, `t`, `y0`, and
+`y1`. It returns deterministic train/val/test splits and caches the dataset under
+`~/.cache/otxlearner/twins`.

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,3 +1,11 @@
 from .ihdp import IHDPDataset, IHDPSplit, load_ihdp
+from .twins import TwinsDataset, TwinsSplit, load_twins
 
-__all__ = ["IHDPDataset", "IHDPSplit", "load_ihdp"]
+__all__ = [
+    "IHDPDataset",
+    "IHDPSplit",
+    "load_ihdp",
+    "TwinsDataset",
+    "TwinsSplit",
+    "load_twins",
+]

--- a/src/data/twins.py
+++ b/src/data/twins.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+__all__ = ["TwinsSplit", "TwinsDataset", "load_twins"]
+
+URL = "https://example.com/twins.npz"
+
+
+@dataclass
+class TwinsSplit:
+    x: np.ndarray
+    t: np.ndarray
+    yf: np.ndarray
+    ycf: np.ndarray
+    mu0: np.ndarray
+    mu1: np.ndarray
+
+
+@dataclass
+class TwinsDataset:
+    train: TwinsSplit
+    val: TwinsSplit
+    test: TwinsSplit
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        return
+    with urllib.request.urlopen(url) as resp:
+        dest.write_bytes(resp.read())
+
+
+def _load_npz(path: Path) -> dict[str, np.ndarray]:
+    data = np.load(path, allow_pickle=False)
+    return {k: data[k] for k in data.files}
+
+
+def load_twins(
+    root: str | Path = Path.home() / ".cache" / "otxlearner" / "twins",
+    *,
+    val_fraction: float = 0.1,
+    seed: int = 42,
+) -> TwinsDataset:
+    """Load Twins with deterministic train/val/test splits."""
+    root = Path(root)
+    path = root / "twins.npz"
+    _download(URL, path)
+
+    data = _load_npz(path)
+    x = np.asarray(data["x"])
+    t = np.asarray(data["t"])
+    y0 = np.asarray(data["y0"])
+    y1 = np.asarray(data["y1"])
+
+    rng = np.random.default_rng(seed)
+    idx = np.arange(x.shape[0])
+    rng.shuffle(idx)
+
+    val_size = int(len(idx) * val_fraction)
+    train_idx = idx[: -val_size * 2]
+    val_idx = idx[-val_size * 2 : -val_size]
+    test_idx = idx[-val_size:]
+
+    def split(i: np.ndarray) -> TwinsSplit:
+        return TwinsSplit(
+            x=x[i],
+            t=t[i],
+            yf=np.where(t[i] == 1, y1[i], y0[i]),
+            ycf=np.where(t[i] == 1, y0[i], y1[i]),
+            mu0=y0[i],
+            mu1=y1[i],
+        )
+
+    train = split(train_idx)
+    val = split(val_idx)
+    test = split(test_idx)
+
+    return TwinsDataset(train=train, val=val, test=test)

--- a/tests/test_twins_loader.py
+++ b/tests/test_twins_loader.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.data import load_twins
+
+
+def _create_fake_dataset(path: Path) -> None:
+    n, d = 100, 5
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=(n, d))
+    t = rng.integers(0, 2, size=n)
+    y0 = rng.normal(size=n)
+    y1 = rng.normal(size=n)
+    np.savez(path / "twins.npz", x=x, t=t, y0=y0, y1=y1)
+
+
+def test_twins_deterministic(tmp_path: Path) -> None:
+    _create_fake_dataset(tmp_path)
+    ds1 = load_twins(tmp_path, val_fraction=0.2, seed=0)
+    ds2 = load_twins(tmp_path, val_fraction=0.2, seed=0)
+    assert np.array_equal(ds1.train.x, ds2.train.x)
+    assert np.array_equal(ds1.val.x, ds2.val.x)
+    assert np.array_equal(ds1.test.x, ds2.test.x)
+
+
+def test_twins_split_shapes(tmp_path: Path) -> None:
+    _create_fake_dataset(tmp_path)
+    ds = load_twins(tmp_path, val_fraction=0.2, seed=1)
+    n = 100
+    val_size = int(n * 0.2)
+    test_size = val_size
+    train_size = n - val_size - test_size
+    assert ds.train.x.shape == (train_size, 5)
+    assert ds.val.x.shape == (val_size, 5)
+    assert ds.test.x.shape == (test_size, 5)


### PR DESCRIPTION
## Summary
- implement `load_twins()` to return deterministic train/val/test splits
- expose Twins loader in `src/data/__init__.py`
- document Twins dataset usage in README
- test determinism and split shapes for the Twins loader

## Testing
- `ruff check --fix src tests`
- `black src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686277c0f0408324872491d5db0b1312