### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  cpu:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    env:
+      IHDP_DATA: ~/.cache/otxlearner/ihdp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/otxlearner
+          key: ${{ runner.os }}-ihdp
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install geomloss pytest
+      - name: Prepare dataset
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from src.data import load_ihdp
+          load_ihdp(Path('$IHDP_DATA'))
+          PY
+      - name: Ruff
+        run: ruff check src tests
+      - name: Black
+        run: black --check src tests
+      - name: Mypy
+        run: mypy --strict src
+      - name: Pytest
+        run: pytest -vv
+
+  cuda:
+    runs-on: ubuntu-latest
+    container:
+      image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    env:
+      IHDP_DATA: /github/home/.cache/otxlearner/ihdp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: cuda-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            cuda-pip-${{ matrix.python-version }}-
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/otxlearner
+          key: cuda-ihdp
+      - name: Install dependencies
+        run: |
+          apt-get update && apt-get install -y git
+          python -m pip install -r requirements.txt
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cu118
+          python -m pip install geomloss pytest
+      - name: Prepare dataset
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from src.data import load_ihdp
+          load_ihdp(Path('$IHDP_DATA'))
+          PY
+      - name: Ruff
+        run: ruff check src tests
+      - name: Black
+        run: black --check src tests
+      - name: Mypy
+        run: mypy --strict src
+      - name: Pytest
+        run: pytest -vv
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture()
+def ihdp_root(tmp_path: Path) -> Path:
+    root_env = os.getenv("IHDP_DATA")
+    if root_env:
+        path = Path(root_env)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    return tmp_path

--- a/tests/test_ihdp_loader.py
+++ b/tests/test_ihdp_loader.py
@@ -9,15 +9,15 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.data import load_ihdp
 
 
-def test_ihdp_deterministic(tmp_path) -> None:
-    ds1 = load_ihdp(tmp_path, val_fraction=0.2, seed=0)
-    ds2 = load_ihdp(tmp_path, val_fraction=0.2, seed=0)
+def test_ihdp_deterministic(ihdp_root: Path) -> None:
+    ds1 = load_ihdp(ihdp_root, val_fraction=0.2, seed=0)
+    ds2 = load_ihdp(ihdp_root, val_fraction=0.2, seed=0)
     assert np.array_equal(ds1.train.x, ds2.train.x)
     assert np.array_equal(ds1.val.x, ds2.val.x)
 
 
-def test_ihdp_split_sizes(tmp_path) -> None:
-    ds = load_ihdp(tmp_path, val_fraction=0.1, seed=1)
+def test_ihdp_split_sizes(ihdp_root: Path) -> None:
+    ds = load_ihdp(ihdp_root, val_fraction=0.1, seed=1)
     n_total = 67200
     assert ds.train.x.shape[0] + ds.val.x.shape[0] == n_total
     assert ds.test.x.shape[0] == 7500

--- a/tests/test_train_smoke.py
+++ b/tests/test_train_smoke.py
@@ -8,14 +8,14 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.train import train
 
 
-def test_train_smoke(tmp_path: Path) -> None:
+def test_train_smoke(ihdp_root: Path) -> None:
     train(
-        root=tmp_path,
+        root=ihdp_root,
         epochs=1,
         batch_size=32,
         lr=1e-3,
         lambda_max=0.1,
         epsilon=0.05,
         patience=1,
-        log_dir=tmp_path / "logs",
+        log_dir=ihdp_root / "logs",
     )


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for linting, typing, and tests
- cache pip packages and IHDP dataset to speed up CI
- add pytest fixture to reuse cached dataset

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686278081eb0832499b3d263fc7f2a2e