### PR TITLE
Fix CUDA workflow apt issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
           key: cuda-ihdp
       - name: Install dependencies
         run: |
-          apt-get update && apt-get install -y git
           python -m pip install -r requirements.txt
           python -m pip install torch --index-url https://download.pytorch.org/whl/cu118
           python -m pip install geomloss pytest


### PR DESCRIPTION
## Summary
- remove redundant apt install from the CUDA runner

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f709fbb88324991ebaef88561b9e