### PR TITLE
Implement cross-fitted propensities and pseudo-outcome baseline

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -32,7 +32,7 @@ def evaluate(
 
     device = torch.device(device)
     ds_np = load_ihdp(data_root)
-    ds = torchify(ds_np)
+    ds = torchify(ds_np, None)
     loader = DataLoader(ds.test, batch_size=batch_size)
 
     model = MLPEncoder(ds.test.x.shape[1]).to(device)
@@ -47,7 +47,7 @@ def evaluate(
     tau_preds: list[torch.Tensor] = []
     tau_targets: list[torch.Tensor] = []
     with torch.no_grad():
-        for x, t, _yf, mu0, mu1 in loader:
+        for x, t, _yf, mu0, mu1, _e_hat in loader:
             x, t, mu0, mu1 = (
                 x.to(device),
                 t.to(device),

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,6 @@
-from .metrics import ate, pehe
+from __future__ import annotations
 
-__all__ = ["pehe", "ate"]
+from .metrics import ate, pehe
+from .propensity import crossfit_propensity, estimate_propensity_splits
+
+__all__ = ["pehe", "ate", "crossfit_propensity", "estimate_propensity_splits"]

--- a/src/utils/propensity.py
+++ b/src/utils/propensity.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
+
+import numpy as np
+import numpy.typing as npt
+from sklearn.linear_model import LogisticRegression  # type: ignore[import-untyped]
+from sklearn.model_selection import KFold  # type: ignore[import-untyped]
+
+
+Array = npt.NDArray[np.float64]
+
+if TYPE_CHECKING:  # pragma: no cover - type hints
+    from ..data import IHDPDataset
+
+
+def crossfit_propensity(
+    x: Array,
+    t: Array,
+    *,
+    folds: int = 5,
+    seed: int = 0,
+    clip: float | None = None,
+) -> Array:
+    """Estimate propensities via K-fold cross-fitted logistic regression."""
+    kf = KFold(n_splits=folds, shuffle=True, random_state=seed)
+    preds = np.empty_like(t, dtype=np.float64)
+    for train_idx, val_idx in kf.split(x):
+        model = LogisticRegression(max_iter=1000)
+        model.fit(x[train_idx], t[train_idx])
+        preds[val_idx] = model.predict_proba(x[val_idx])[:, 1]
+    if clip is not None:
+        preds = np.clip(preds, clip, 1 - clip)
+    return preds
+
+
+def estimate_propensity_splits(
+    ds: "IHDPDataset",
+    *,
+    folds: int = 5,
+    seed: int = 0,
+    epsilon_prop: float = 0.05,
+) -> Tuple[Array, Array, Array]:
+    """Return clipped cross-fitted propensities for train/val/test."""
+    import numpy as np
+    from sklearn.linear_model import LogisticRegression
+
+    x_train_val = np.concatenate([ds.train.x, ds.val.x])
+    t_train_val = np.concatenate([ds.train.t, ds.val.t])
+
+    cf_pred = crossfit_propensity(
+        x_train_val, t_train_val, folds=folds, seed=seed, clip=epsilon_prop
+    )
+    n_train = ds.train.x.shape[0]
+    p_train = cf_pred[:n_train]
+    p_val = cf_pred[n_train:]
+
+    model_full = LogisticRegression(max_iter=1000)
+    model_full.fit(x_train_val, t_train_val)
+    p_test = model_full.predict_proba(ds.test.x)[:, 1]
+    p_test = np.clip(p_test, epsilon_prop, 1 - epsilon_prop)
+    return p_train, p_val, p_test

--- a/tests/test_propensity.py
+++ b/tests/test_propensity.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import numpy as np
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.utils.propensity import crossfit_propensity
+
+
+def test_crossfit_deterministic() -> None:
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=(100, 5))
+    t = rng.integers(0, 2, size=100)
+    p1 = crossfit_propensity(x, t, folds=3, seed=42)
+    p2 = crossfit_propensity(x, t, folds=3, seed=42)
+    assert np.allclose(p1, p2)

--- a/tests/test_train_smoke.py
+++ b/tests/test_train_smoke.py
@@ -9,7 +9,7 @@ from src.train import train
 
 
 def test_train_smoke(ihdp_root: Path) -> None:
-    train(
+    history = train(
         root=ihdp_root,
         epochs=1,
         batch_size=32,
@@ -19,3 +19,5 @@ def test_train_smoke(ihdp_root: Path) -> None:
         patience=1,
         log_dir=ihdp_root / "logs",
     )
+    assert len(history) == 2
+    assert history[-1] < history[0]


### PR DESCRIPTION
## Summary
- add a propensity module implementing K-fold cross-fitted logistic regression
- clip propensities and include them when converting IHDP datasets
- train the baseline using pseudo-outcomes instead of ground truth τ
- evaluate and DataLoader updated for the new dataset format
- unit tests check deterministic propensity splits and that val_PEHE_proxy drops after one epoch

## Testing
- `ruff check . --fix`
- `black src/train.py src/utils/propensity.py tests/test_propensity.py tests/test_train_smoke.py`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686309b10abc8324adf3a6792e0b69b8