### PR TITLE
Drop CUDA Python 3.11 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10']
     env:
       IHDP_DATA: /github/home/.cache/otxlearner/ihdp
     steps:


### PR DESCRIPTION
## Summary
- remove Python 3.11 from the CUDA matrix in CI

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630b773e088324b9f881f81f47761e