### PR TITLE
Add ACIC dataset loader with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ train/val/test splits. By default data are cached under `~/.cache/otxlearner/ihd
 `y1`. It returns deterministic train/val/test splits and caches the dataset under
 `~/.cache/otxlearner/twins`.
 
+`load_acic()` expects an `acic.npz` archive with arrays `x`, `t`, `y0`, and
+`y1`. By default data are cached under `~/.cache/otxlearner/acic` and the
+function returns deterministic train/val/test splits.
+
 ## Quick start
 
 Install the required packages and run a short training session on IHDP. The

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,10 +1,14 @@
 from .ihdp import IHDPDataset, IHDPSplit, load_ihdp
 from .twins import TwinsDataset, TwinsSplit, load_twins
+from .acic import ACICDataset, ACICSplit, load_acic
 
 __all__ = [
     "IHDPDataset",
     "IHDPSplit",
     "load_ihdp",
+    "ACICDataset",
+    "ACICSplit",
+    "load_acic",
     "TwinsDataset",
     "TwinsSplit",
     "load_twins",

--- a/src/data/acic.py
+++ b/src/data/acic.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import numpy.typing as npt
+
+__all__ = ["ACICSplit", "ACICDataset", "load_acic"]
+
+URL = "https://example.com/acic.npz"
+
+
+@dataclass
+class ACICSplit:
+    x: npt.NDArray[np.float64]
+    t: npt.NDArray[np.float64]
+    yf: npt.NDArray[np.float64]
+    ycf: npt.NDArray[np.float64]
+    mu0: npt.NDArray[np.float64]
+    mu1: npt.NDArray[np.float64]
+
+
+@dataclass
+class ACICDataset:
+    train: ACICSplit
+    val: ACICSplit
+    test: ACICSplit
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        return
+    with urllib.request.urlopen(url) as resp:
+        dest.write_bytes(resp.read())
+
+
+def _load_npz(path: Path) -> dict[str, npt.NDArray[np.float64]]:
+    data = np.load(path, allow_pickle=False)
+    return {k: data[k] for k in data.files}
+
+
+def load_acic(
+    root: str | Path = Path.home() / ".cache" / "otxlearner" / "acic",
+    *,
+    val_fraction: float = 0.1,
+    test_fraction: float = 0.1,
+    seed: int = 42,
+) -> ACICDataset:
+    """Load ACIC with deterministic train/val/test splits."""
+    root = Path(root)
+    path = root / "acic.npz"
+    _download(URL, path)
+
+    data = _load_npz(path)
+    x = np.asarray(data["x"])
+    t = np.asarray(data["t"])
+    y0 = np.asarray(data["y0"])
+    y1 = np.asarray(data["y1"])
+
+    rng = np.random.default_rng(seed)
+    idx = np.arange(x.shape[0])
+    rng.shuffle(idx)
+
+    val_size = int(len(idx) * val_fraction)
+    test_size = int(len(idx) * test_fraction)
+    train_idx = idx[: -val_size - test_size]
+    val_idx = idx[-val_size - test_size : -test_size]
+    test_idx = idx[-test_size:]
+
+    def split(i: npt.NDArray[np.int_]) -> ACICSplit:
+        return ACICSplit(
+            x=x[i],
+            t=t[i],
+            yf=np.where(t[i] == 1, y1[i], y0[i]),
+            ycf=np.where(t[i] == 1, y0[i], y1[i]),
+            mu0=y0[i],
+            mu1=y1[i],
+        )
+
+    train = split(train_idx)
+    val = split(val_idx)
+    test = split(test_idx)
+
+    return ACICDataset(train=train, val=val, test=test)

--- a/tests/test_acic_loader.py
+++ b/tests/test_acic_loader.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.data import load_acic
+
+
+def _create_fake_dataset(path: Path) -> None:
+    n, d = 120, 4
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=(n, d))
+    t = rng.integers(0, 2, size=n)
+    y0 = rng.normal(size=n)
+    y1 = rng.normal(size=n)
+    np.savez(path / "acic.npz", x=x, t=t, y0=y0, y1=y1)
+
+
+def test_acic_deterministic(tmp_path: Path) -> None:
+    _create_fake_dataset(tmp_path)
+    ds1 = load_acic(tmp_path, val_fraction=0.2, test_fraction=0.1, seed=0)
+    ds2 = load_acic(tmp_path, val_fraction=0.2, test_fraction=0.1, seed=0)
+    assert np.array_equal(ds1.train.x, ds2.train.x)
+    assert np.array_equal(ds1.val.x, ds2.val.x)
+    assert np.array_equal(ds1.test.x, ds2.test.x)
+
+
+def test_acic_split_shapes(tmp_path: Path) -> None:
+    _create_fake_dataset(tmp_path)
+    ds = load_acic(tmp_path, val_fraction=0.2, test_fraction=0.1, seed=1)
+    n = 120
+    val_size = int(n * 0.2)
+    test_size = int(n * 0.1)
+    train_size = n - val_size - test_size
+    assert ds.train.x.shape == (train_size, 4)
+    assert ds.val.x.shape == (val_size, 4)
+    assert ds.test.x.shape == (test_size, 4)


### PR DESCRIPTION
## Summary
- add ACIC dataset loader that caches `acic.npz` and produces deterministic splits
- export loader from `src/data/__init__`
- document loader in README
- test reproducible splits for ACIC

## Testing
- `ruff check src/data/acic.py src/data/__init__.py tests/test_acic_loader.py`
- `black src/data/acic.py src/data/__init__.py tests/test_acic_loader.py -q`
- `mypy --strict src/data/acic.py src/data/__init__.py tests/test_acic_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68633c3ddb08832487bd1faa4abb663b