### PR TITLE
Add Hydra config support

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -1,0 +1,10 @@
+data_root: ~/.cache/otxlearner/ihdp
+epochs: 5
+batch_size: 512
+lr: 0.001
+lambda_max: 1.0
+epsilon: 0.05
+patience: 5
+log_dir: null
+device: cpu
+seed: 42

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ black==24.3.0
 tensorboard==2.19.0
 mypy==1.8.0
 scikit-learn==1.7.0
+hydra-core==1.3.2


### PR DESCRIPTION
## Summary
- add optional Hydra-based configuration loading
- create `TrainConfig` dataclass and helper
- add example YAML file under `configs/`
- include `hydra-core` in requirements

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863405741b083249621315284157dc4