### PR TITLE
Use uv for dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,19 +21,21 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+            ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-uv-${{ matrix.python-version }}-
       - uses: actions/cache@v3
         with:
           path: ~/.cache/otxlearner
           key: ${{ runner.os }}-ihdp
+      - name: Install uv
+        run: python -m pip install uv
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt
-          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-          python -m pip install geomloss pytest
+          uv pip install -r requirements.txt
+          uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+          uv pip install geomloss pytest
       - name: Prepare dataset
         run: |
           python - <<'PY'
@@ -72,19 +74,21 @@ jobs:
           python -m pip install --upgrade pip
       - uses: actions/cache@v3
         with:
-          path: ~/.cache/pip
-          key: cuda-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          path: ~/.cache/uv
+          key: cuda-uv-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            cuda-pip-${{ matrix.python-version }}-
+            cuda-uv-${{ matrix.python-version }}-
       - uses: actions/cache@v3
         with:
           path: ~/.cache/otxlearner
           key: cuda-ihdp
+      - name: Install uv
+        run: python -m pip install uv
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt
-          python -m pip install torch --index-url https://download.pytorch.org/whl/cu118
-          python -m pip install geomloss pytest
+          uv pip install -r requirements.txt
+          uv pip install torch --index-url https://download.pytorch.org/whl/cu118
+          uv pip install geomloss pytest
       - name: Prepare dataset
         run: |
           python - <<'PY'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         run: python -m pip install uv
       - name: Install dependencies
         run: |
-          uv pip install -r requirements.txt
-          uv pip install torch --index-url https://download.pytorch.org/whl/cpu
-          uv pip install geomloss pytest
+          uv pip install --system -r requirements.txt
+          uv pip install --system torch --index-url https://download.pytorch.org/whl/cpu
+          uv pip install --system geomloss pytest
       - name: Prepare dataset
         run: |
           python - <<'PY'
@@ -86,9 +86,9 @@ jobs:
         run: python -m pip install uv
       - name: Install dependencies
         run: |
-          uv pip install -r requirements.txt
-          uv pip install torch --index-url https://download.pytorch.org/whl/cu118
-          uv pip install geomloss pytest
+          uv pip install --system -r requirements.txt
+          uv pip install --system torch --index-url https://download.pytorch.org/whl/cu118
+          uv pip install --system geomloss pytest
       - name: Prepare dataset
         run: |
           python - <<'PY'


### PR DESCRIPTION
## Summary
- use `uv` to install dependencies for faster CI
- cache `~/.cache/uv` instead of pip cache
- install `uv` in both CPU and CUDA GitHub workflows

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68635a69bbe88324b90cf3f816044e1f