### PR TITLE
Add Optuna sweep script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mypy==1.8.0
 scikit-learn==1.7.0
 hydra-core==1.3.2
 wandb==0.16.4
+optuna==3.6.0

--- a/src/sweep.py
+++ b/src/sweep.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Optional
+import importlib
+
+import optuna
+
+from .train import train
+
+_wandb: Optional[ModuleType]
+try:  # pragma: no cover - optional dependency
+    _wandb = importlib.import_module("wandb")
+except Exception:
+    _wandb = None
+wandb: Optional[ModuleType] = _wandb
+
+__all__ = ["run_study", "suggest"]
+
+
+def suggest(trial: optuna.trial.Trial) -> dict[str, Any]:
+    return {
+        "lr": trial.suggest_float("lr", 1e-4, 5e-3, log=True),
+        "lambda_": trial.suggest_float("lambda", 1e-2, 10.0, log=True),
+        "blur": trial.suggest_float("blur", 0.01, 0.1),
+        "depth": trial.suggest_int("layers", 2, 4),
+        "width": trial.suggest_categorical("width", [64, 128, 256]),
+    }
+
+
+def objective(trial: optuna.trial.Trial, root: Path) -> float:
+    params = suggest(trial)
+    history = train(
+        root,
+        epochs=1,
+        batch_size=32,
+        lr=params["lr"],
+        lambda_max=params["lambda_"],
+        epsilon=params["blur"],
+        patience=1,
+        depth=params["depth"],
+        width=params["width"],
+        wandb_log=False,
+    )
+    return history[-1]
+
+
+def run_study(
+    n_trials: int = 10, root: Path | str = Path.home() / ".cache/otxlearner/ihdp"
+) -> optuna.study.Study:
+    study = optuna.create_study(direction="minimize")
+    study.optimize(lambda t: objective(t, Path(root)), n_trials=n_trials)
+    if wandb is not None:
+        run = wandb.init(project="otxlearner", job_type="optuna")
+        run.summary.update({"best_value": study.best_value, **study.best_params})
+        run.finish()
+    print("Best trial", study.best_trial.number, study.best_value)
+    return study
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    run_study()

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.sweep import run_study
+
+
+def test_sweep_runs_one_trial(ihdp_root: Path) -> None:
+    study = run_study(n_trials=1, root=ihdp_root)
+    assert len(study.trials) == 1


### PR DESCRIPTION
## Summary
- make MLPEncoder configurable via `hidden_sizes`
- add `depth` and `width` hyperparameters to train
- implement `sweep.py` using Optuna to sample search space
- log best trial to W&B
- test running a single Optuna trial
- include Optuna in requirements

## Testing
- `mypy --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863629fdc888324bd4a6d8794eb4c76