### PR TITLE
Add domain-adversarial variant

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -3,5 +3,12 @@ from __future__ import annotations
 from .sinkhorn import Sinkhorn
 from .mlp import MLPEncoder
 from .flow import FlowEncoder
+from .domain import GradientReversal, DomainDiscriminator
 
-__all__ = ["MLPEncoder", "FlowEncoder", "Sinkhorn"]
+__all__ = [
+    "MLPEncoder",
+    "FlowEncoder",
+    "Sinkhorn",
+    "GradientReversal",
+    "DomainDiscriminator",
+]

--- a/src/models/domain.py
+++ b/src/models/domain.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import torch
+from torch import nn
+
+
+class _GradientReversalFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx: Any, x: torch.Tensor, lambd: float) -> torch.Tensor:
+        ctx.lambd = lambd
+        return x.view_as(x)
+
+    @staticmethod
+    def backward(ctx: Any, *grad_outputs: torch.Tensor) -> tuple[torch.Tensor, None]:
+        (grad_output,) = grad_outputs
+        return -ctx.lambd * grad_output, None
+
+
+class GradientReversal(nn.Module):
+    """Gradient reversal layer from DANN."""
+
+    def forward(self, x: torch.Tensor, lambd: float) -> torch.Tensor:
+        return cast(torch.Tensor, _GradientReversalFn.apply(x, lambd))  # type: ignore[no-untyped-call]
+
+
+class DomainDiscriminator(nn.Module):
+    """Simple discriminator predicting treatment domain."""
+
+    def __init__(self, input_dim: int, hidden_dim: int = 32) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 2),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - thin
+        return cast(torch.Tensor, self.net(x))
+
+
+__all__ = ["GradientReversal", "DomainDiscriminator"]

--- a/tests/test_dann_smoke.py
+++ b/tests/test_dann_smoke.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.train import train
+
+
+def test_train_dann_smoke(ihdp_root: Path) -> None:
+    history = train(
+        root=ihdp_root,
+        epochs=2,
+        batch_size=32,
+        lr=1e-3,
+        lambda_max=0.1,
+        epsilon=0.05,
+        patience=1,
+        log_dir=ihdp_root / "logs",
+        dann=True,
+    )
+    assert len(history) >= 2
+    assert history[-1] <= history[0]

--- a/tests/test_gradient_reversal.py
+++ b/tests/test_gradient_reversal.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import torch
+from src.models.domain import GradientReversal
+
+
+def test_gradient_reversal_backward() -> None:
+    layer = GradientReversal()
+    x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+    y = layer(x, 0.5)
+    y.sum().backward()
+    assert torch.allclose(x.grad, torch.tensor([-0.5, -0.5, -0.5]))
+    assert torch.allclose(y, x)


### PR DESCRIPTION
## Summary
- implement gradient reversal and domain discriminator
- add optional `dann` mode replacing Sinkhorn loss
- include unit tests and DANN smoke test
- adjust types so mypy passes

## Testing
- `ruff check .`
- `black --check .`
- `mypy --strict src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686376bb94e48324bca6861763004c3a