### PR TITLE
Add robust dataset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ This repository currently contains a minimal project skeleton. Code lives under
 `load_ihdp()` downloads the public IHDP benchmark and returns deterministic
 train/val/test splits. By default data are cached under `~/.cache/otxlearner/ihdp`.
 
-`load_twins()` expects a `twins.npz` archive with arrays `x`, `t`, `y0`, and
-`y1`. It returns deterministic train/val/test splits and caches the dataset under
+`load_twins()` downloads the Twins benchmark if needed and returns deterministic
+train/val/test splits. By default data are cached under
 `~/.cache/otxlearner/twins`.
 
-`load_acic()` expects an `acic.npz` archive with arrays `x`, `t`, `y0`, and
-`y1`. By default data are cached under `~/.cache/otxlearner/acic` and the
-function returns deterministic train/val/test splits.
+`load_acic()` supports the ACIC 2016 and 2018 benchmarks. The dataset is
+downloaded on first use and cached under `~/.cache/otxlearner/acic`.
 
 ## Quick start
 

--- a/src/otxlearner/data/types.py
+++ b/src/otxlearner/data/types.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+from typing import Protocol
+
+__all__ = ["SplitProtocol", "DatasetProtocol"]
+
+
+class SplitProtocol(Protocol):
+    x: npt.NDArray[np.float64]
+    t: npt.NDArray[np.float64]
+    yf: npt.NDArray[np.float64]
+    ycf: npt.NDArray[np.float64]
+    mu0: npt.NDArray[np.float64]
+    mu1: npt.NDArray[np.float64]
+
+
+class DatasetProtocol(Protocol):
+    train: SplitProtocol
+    val: SplitProtocol
+    test: SplitProtocol

--- a/src/otxlearner/data/utils.py
+++ b/src/otxlearner/data/utils.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import hashlib
+import urllib.request
+from pathlib import Path
+import tarfile
+import zipfile
+
+__all__ = ["download", "download_and_extract", "sha256sum"]
+
+
+def sha256sum(path: Path) -> str:
+    hash_obj = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hash_obj.update(chunk)
+    return hash_obj.hexdigest()
+
+
+def download(url: str, dest: Path, *, sha256: str | None = None) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        if sha256 is None or sha256sum(dest) == sha256:
+            return
+        dest.unlink()
+    with urllib.request.urlopen(url) as resp:
+        data = resp.read()
+    if sha256 is not None and hashlib.sha256(data).hexdigest() != sha256:
+        raise ValueError("Checksum mismatch")
+    dest.write_bytes(data)
+
+
+def download_and_extract(url: str, dest: Path, *, sha256: str | None = None) -> Path:
+    download(url, dest, sha256=sha256)
+    out_dir = dest.parent
+    if dest.suffix == ".zip":
+        with zipfile.ZipFile(dest) as zf:
+            zf.extractall(out_dir)
+    elif dest.suffix in {".gz", ".tgz"} or dest.suffixes[-2:] == [".tar", ".gz"]:
+        with tarfile.open(dest) as tf:
+            tf.extractall(out_dir)
+    return out_dir


### PR DESCRIPTION
## Summary
- implement download utilities with checksum support
- auto-download ACIC and Twins datasets and allow custom paths
- add dataset selection flag to train/evaluate
- document datasets in README

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d1505af88324a4ac9f1b19e4df41