### PR TITLE
Add MkDocs documentation and pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
+  - repo: local
+    hooks:
+      - id: mkdocs-build
+        name: mkdocs build
+        entry: mkdocs build --strict --quiet
+        language: system
+        files: "^(docs/|src/.*\.py$)"

--- a/README.md
+++ b/README.md
@@ -1,45 +1,41 @@
-# OTX Learner
+# OTX Learner [![PyPI](https://img.shields.io/pypi/v/otxlearner.svg)](https://pypi.org/project/otxlearner/)
 
-This project implements a Sinkhorn-penalised X-Net architecture for causal inference.
-Refer to `Prompt.md` for the full research notes.
+OTX Learner is an experimental implementation of a **Sinkhorn‑penalised X‑Net** for counterfactual inference with PyTorch. It balances treated and control representations using an entropic optimal‑transport divergence rather than an adversarial critic.
 
-This repository currently contains a minimal project skeleton. Code lives under
-`src/otxlearner`, configurations under `configs/`, and tests under `tests/`.
+The code lives under `src/otxlearner` and includes dataset loaders, models and training scripts.
+
+```python
+from otxlearner.train import main
+
+# run a short IHDP experiment
+main(["--epochs", "5", "--log-dir", "runs/ihdp"])
+```
+
+See the [documentation](https://otxlearner.readthedocs.io/) for a quick-start guide, API reference and research notes.
 
 ## Dataset loaders
 
-`load_ihdp()` downloads the public IHDP benchmark and returns deterministic
-train/val/test splits. By default data are cached under `~/.cache/otxlearner/ihdp`.
+`load_ihdp()` downloads the public IHDP benchmark and returns deterministic train/val/test splits. By default data are cached under `~/.cache/otxlearner/ihdp`.
 
-`load_twins()` downloads the Twins benchmark if needed and returns deterministic
-train/val/test splits. By default data are cached under
-`~/.cache/otxlearner/twins`.
+`load_twins()` downloads the Twins benchmark if needed and returns deterministic train/val/test splits. By default data are cached under `~/.cache/otxlearner/twins`.
 
-`load_acic()` supports the ACIC 2016 and 2018 benchmarks. The dataset is
-downloaded on first use and cached under `~/.cache/otxlearner/acic`.
+`load_acic()` supports the ACIC 2016 and 2018 benchmarks. The dataset is downloaded on first use and cached under `~/.cache/otxlearner/acic`.
 
 ## Quick start
 
-Install the required packages and run a short training session on IHDP. The
-dataset is downloaded automatically on first use.
+Install the required packages and run a short training session on IHDP.
 
 ```bash
-python -m pip install torch geomloss  # plus other deps in requirements.txt
+python -m pip install torch geomloss
 python -m pip install -r requirements.txt
 python -m pip install -e .
 
-# train for a few epochs and log metrics under `runs/ihdp`
 python -m otxlearner.train --epochs 5 --log-dir runs/ihdp
-
-# evaluate a saved checkpoint (if you saved `model.pt` during training)
-python -m otxlearner.evaluate model.pt --data-root ~/.cache/otxlearner/ihdp \
-    --csv results.csv --plot results.png
 ```
 
-The [training_curves.ipynb](notebooks/training_curves.ipynb) notebook shows how
-to visualise the TensorBoard logs produced during training.
+The [training_curves.ipynb](notebooks/training_curves.ipynb) notebook shows how to visualise the TensorBoard logs produced during training.
 
 ## Experiment tracking
 
-Set the `WANDB_API_KEY` environment variable or run `wandb login` to enable
-Weights & Biases logging via `--wandb` on the train and evaluate scripts.
+Set the `WANDB_API_KEY` environment variable or run `wandb login` to enable Weights & Biases logging via `--wandb` on the train and evaluate scripts.
+

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: otxlearner

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,6 @@
+# FAQ
+
+**Why Sinkhorn?** The entropic OT penalty provides smooth gradients and unbiased mini-batch estimates, making optimisation stable.
+
+**Where can I find the code?** The source lives under `src/otxlearner`.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# OTX Learner Documentation
+
+Welcome to the **OTX Learner** docs. The project implements a Sinkhorn-penalised X-Net for causal inference with PyTorch.
+
+Use the navigation on the left to find installation instructions, API reference and detailed research notes.
+

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,0 +1,15 @@
+# Quick Start
+
+Install the package and run a short training session on the IHDP dataset.
+
+```bash
+python -m pip install torch geomloss
+python -m pip install -r requirements.txt
+python -m pip install -e .
+
+# train for a few epochs and log metrics
+python -m otxlearner.train --epochs 5 --log-dir runs/ihdp
+```
+
+See the `notebooks/training_curves.ipynb` notebook for visualising TensorBoard logs.
+

--- a/docs/research_notes.md
+++ b/docs/research_notes.md
@@ -1,0 +1,9 @@
+# Research Notes
+
+The following sections summarise the ideas from `Prompt.md`.
+
+<!-- include the entire Prompt.md content for now -->
+
+```{literalinclude} ../Prompt.md
+:language: markdown
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,18 @@
+site_name: OTX Learner
+site_url: https://otxlearner.readthedocs.io
+theme:
+  name: material
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          setup_commands:
+            - import sys; sys.path.insert(0, 'src')
+nav:
+  - Home: index.md
+  - Quick Start: quick_start.md
+  - API Reference: api_reference.md
+  - Research Notes: research_notes.md
+  - FAQ: faq.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ jax==0.6.2
 jaxlib==0.6.2
 ott-jax==0.5.0
 jax2torch==0.0.7
+mkdocs==1.5.3
+mkdocs-material==9.5.5
+mkdocstrings[python]==0.24.0


### PR DESCRIPTION
## Summary
- publish project docs via MkDocs
- add Quick Start, API reference, research notes and FAQ pages
- update README with project blurb, badge and example
- install MkDocs dependencies
- enforce `mkdocs build` in pre‑commit hooks

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`
- `mkdocs build --strict --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6864d8b2259883248a82dc7a92b864fe