### PR TITLE
Add Hydra configs and Optuna sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+runs/

--- a/configs/acic.yaml
+++ b/configs/acic.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - base
+  - _self_
+
+data: acic
+data_root: ~/.cache/otxlearner/acic

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -1,3 +1,4 @@
+data: ihdp
 data_root: ~/.cache/otxlearner/ihdp
 epochs: 5
 batch_size: 512

--- a/configs/ihdp.yaml
+++ b/configs/ihdp.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - base
+  - _self_
+
+data: ihdp
+data_root: ~/.cache/otxlearner/ihdp

--- a/configs/twins.yaml
+++ b/configs/twins.yaml
@@ -1,0 +1,6 @@
+defaults:
+  - base
+  - _self_
+
+data: twins
+data_root: ~/.cache/otxlearner/twins

--- a/src/otxlearner/sweep.py
+++ b/src/otxlearner/sweep.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Optional
 import importlib
 
 import optuna
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
 
-from .train import train
+from .train import train_from_config
 
 _wandb: Optional[ModuleType]
 try:  # pragma: no cover - optional dependency
@@ -24,40 +24,56 @@ __all__ = ["run_study", "suggest"]
 def suggest(trial: optuna.trial.Trial) -> dict[str, Any]:
     return {
         "lr": trial.suggest_float("lr", 1e-4, 5e-3, log=True),
-        "lambda_": trial.suggest_float("lambda", 1e-2, 10.0, log=True),
-        "blur": trial.suggest_float("blur", 0.01, 0.1),
-        "depth": trial.suggest_int("layers", 2, 4),
+        "lambda_max": trial.suggest_float("lambda", 1e-2, 10.0, log=True),
+        "epsilon": trial.suggest_float("epsilon", 0.01, 0.1),
+        "depth": trial.suggest_int("depth", 2, 4),
         "width": trial.suggest_categorical("width", [64, 128, 256]),
     }
 
 
-def objective(trial: optuna.trial.Trial, root: Path) -> float:
+def _objective(
+    trial: optuna.trial.Trial, cfg_path: Path, data_root: Path | None
+) -> float:
     params = suggest(trial)
-    history = train(
-        root,
-        epochs=1,
-        batch_size=32,
-        lr=params["lr"],
-        lambda_max=params["lambda_"],
-        epsilon=params["blur"],
-        patience=1,
-        depth=params["depth"],
-        width=params["width"],
-        wandb_log=False,
-    )
+    overrides = [f"{k}={v}" for k, v in params.items()]
+    if data_root is not None:
+        overrides.append(f"data_root={str(data_root.expanduser())}")
+    trial_dir = Path("runs") / f"trial_{trial.number}"
+    overrides.append(f"log_dir={trial_dir}")
+    with initialize_config_dir(
+        config_dir=str(cfg_path.parent.resolve()), version_base=None
+    ):
+        cfg = compose(config_name=cfg_path.stem, overrides=overrides)
+    history = train_from_config(cfg)  # type: ignore[arg-type]
     return history[-1]
 
 
 def run_study(
-    n_trials: int = 10, root: Path | str = Path.home() / ".cache/otxlearner/ihdp"
+    n_trials: int = 10,
+    cfg_path: Path | str = Path("configs/ihdp.yaml"),
+    *,
+    data_root: Path | None = None,
+    wandb_log: bool = False,
 ) -> optuna.study.Study:
+    cfg = Path(cfg_path)
     study = optuna.create_study(direction="minimize")
-    study.optimize(lambda t: objective(t, Path(root)), n_trials=n_trials)
-    if wandb is not None:
+    study.optimize(lambda t: _objective(t, cfg, data_root), n_trials=n_trials)
+    if wandb_log and wandb is not None:
         run = wandb.init(project="otxlearner", job_type="optuna")
         run.summary.update({"best_value": study.best_value, **study.best_params})
+        best_overrides = [f"{k}={v}" for k, v in study.best_params.items()]
+        if data_root is not None:
+            best_overrides.append(f"data_root={str(data_root.expanduser())}")
+        with initialize_config_dir(
+            config_dir=str(cfg.parent.resolve()), version_base=None
+        ):
+            best_cfg = compose(config_name=cfg.stem, overrides=best_overrides)
+        cfg_file = Path("runs") / "best_config.yaml"
+        OmegaConf.save(best_cfg, cfg_file)
+        artifact = wandb.Artifact("best_config", type="config")
+        artifact.add_file(str(cfg_file))
+        run.log_artifact(artifact)
         run.finish()
-    print("Best trial", study.best_trial.number, study.best_value)
     return study
 
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -4,5 +4,5 @@ from otxlearner.sweep import run_study
 
 
 def test_sweep_runs_one_trial(ihdp_root: Path) -> None:
-    study = run_study(n_trials=1, root=ihdp_root)
+    study = run_study(n_trials=1, cfg_path="configs/ihdp.yaml", data_root=ihdp_root)
     assert len(study.trials) == 1


### PR DESCRIPTION
## Summary
- create dataset-specific Hydra configs
- build optuna sweep runner
- ignore `runs/` outputs
- adjust sweep test for new interface
- expand data root in overrides

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864f37f841083249b4ba7b1926ab755