### PR TITLE
Add modular trainer skeleton

### DIFF
--- a/src/otxlearner/cli.py
+++ b/src/otxlearner/cli.py
@@ -1,0 +1,1 @@
+"""Command-line interface for OTX Learner."""

--- a/src/otxlearner/loops.py
+++ b/src/otxlearner/loops.py
@@ -1,0 +1,1 @@
+"""Training and validation loops."""

--- a/src/otxlearner/registries.py
+++ b/src/otxlearner/registries.py
@@ -1,0 +1,1 @@
+"""Module registries for datasets and trainers."""

--- a/src/otxlearner/schedulers.py
+++ b/src/otxlearner/schedulers.py
@@ -1,0 +1,1 @@
+"""Learning-rate and lambda schedulers."""

--- a/src/otxlearner/trainers/__init__.py
+++ b/src/otxlearner/trainers/__init__.py
@@ -1,0 +1,1 @@
+"""Trainer base class and implementations."""

--- a/src/otxlearner/trainers/base.py
+++ b/src/otxlearner/trainers/base.py
@@ -1,0 +1,1 @@
+"""Abstract trainer base class."""

--- a/src/otxlearner/trainers/dann.py
+++ b/src/otxlearner/trainers/dann.py
@@ -1,0 +1,1 @@
+"""Domain-adversarial trainer."""

--- a/src/otxlearner/trainers/sinkhorn.py
+++ b/src/otxlearner/trainers/sinkhorn.py
@@ -1,0 +1,1 @@
+"""Sinkhorn trainer implementation."""


### PR DESCRIPTION
## Summary
- introduce skeleton modules for trainers and CLI
- add placeholder files for loops, registries and schedulers

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686507a398cc832488a26e1be9a9b768