### PR TITLE
Extract helper modules

### DIFF
--- a/src/otxlearner/data/__init__.py
+++ b/src/otxlearner/data/__init__.py
@@ -1,6 +1,7 @@
 from .ihdp import IHDPDataset, IHDPSplit, load_ihdp
 from .twins import TwinsDataset, TwinsSplit, load_twins
 from .acic import ACICDataset, ACICSplit, load_acic
+from .torch_adapter import TorchIHDP, TorchSplit, torchify
 
 __all__ = [
     "IHDPDataset",
@@ -12,4 +13,7 @@ __all__ = [
     "TwinsDataset",
     "TwinsSplit",
     "load_twins",
+    "TorchIHDP",
+    "TorchSplit",
+    "torchify",
 ]

--- a/src/otxlearner/data/torch_adapter.py
+++ b/src/otxlearner/data/torch_adapter.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+import numpy.typing as npt
+import torch
+
+from .types import DatasetProtocol, SplitProtocol
+
+ArrayF = npt.NDArray[np.float64]
+
+
+@dataclass
+class TorchSplit(torch.utils.data.Dataset[tuple[torch.Tensor, ...]]):
+    """Torch dataset wrapper around :class:`IHDPSplit`."""
+
+    x: torch.Tensor
+    t: torch.Tensor
+    yf: torch.Tensor
+    mu0: torch.Tensor
+    mu1: torch.Tensor
+    e: torch.Tensor
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return self.x.shape[0]
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, ...]:
+        return (
+            self.x[idx],
+            self.t[idx],
+            self.yf[idx],
+            self.mu0[idx],
+            self.mu1[idx],
+            self.e[idx],
+        )
+
+
+@dataclass
+class TorchIHDP:
+    train: TorchSplit
+    val: TorchSplit
+    test: TorchSplit
+
+
+def _to_tensor(x: torch.Tensor | ArrayF) -> torch.Tensor:
+    return torch.as_tensor(x, dtype=torch.float32)
+
+
+def torchify(
+    ds: DatasetProtocol,
+    propensities: tuple[ArrayF, ArrayF, ArrayF] | None = None,
+) -> TorchIHDP:
+    """Convert numpy dataset to PyTorch tensors."""
+
+    def convert(split: SplitProtocol, e: ArrayF) -> TorchSplit:
+        return TorchSplit(
+            _to_tensor(split.x),
+            _to_tensor(split.t),
+            _to_tensor(split.yf),
+            _to_tensor(split.mu0),
+            _to_tensor(split.mu1),
+            _to_tensor(e),
+        )
+
+    if propensities is None:
+        zeros_train = np.zeros(len(ds.train.x), dtype=np.float64)
+        zeros_val = np.zeros(len(ds.val.x), dtype=np.float64)
+        zeros_test = np.zeros(len(ds.test.x), dtype=np.float64)
+        propensities = (zeros_train, zeros_val, zeros_test)
+
+    e_train, e_val, e_test = propensities
+    return TorchIHDP(
+        convert(ds.train, e_train),
+        convert(ds.val, e_val),
+        convert(ds.test, e_test),
+    )
+
+
+__all__ = ["TorchIHDP", "TorchSplit", "_to_tensor", "torchify"]

--- a/src/otxlearner/evaluate.py
+++ b/src/otxlearner/evaluate.py
@@ -16,7 +16,7 @@ from torch.utils.data import DataLoader
 from .data import load_ihdp, load_twins, load_acic
 from .data.types import DatasetProtocol
 from .models import MLPEncoder, Sinkhorn
-from .train import torchify
+from .data.torch_adapter import torchify
 from .utils import ate, pehe
 
 _wandb: Optional[ModuleType]

--- a/src/otxlearner/schedulers.py
+++ b/src/otxlearner/schedulers.py
@@ -1,1 +1,30 @@
+from __future__ import annotations
+
+import torch
+from typing import Callable
+
+
 """Learning-rate and lambda schedulers."""
+
+
+def cosine_warmup_lambda(
+    max_lambda: float, num_epochs: int, warmup_frac: float = 0.1
+) -> Callable[[int], float]:
+    """Return λ schedule that ramps up during the first epochs."""
+
+    warmup_epochs = max(1, int(num_epochs * warmup_frac))
+
+    def schedule(epoch: int) -> float:
+        if epoch < warmup_epochs:
+            val = (
+                max_lambda
+                * (1 - torch.cos(torch.tensor(epoch / warmup_epochs * torch.pi)))
+                / 2
+            )
+            return float(val.item())
+        return float(max_lambda)
+
+    return schedule
+
+
+__all__ = ["cosine_warmup_lambda"]


### PR DESCRIPTION
## Summary
- add `torch_adapter` utilities
- pull out lambda scheduler
- update train loop to use new helpers
- update evaluation to import from new modules

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650ccb66b48324b288b7257be81cb7