### PR TITLE
Implement trainer registries and basic trainers

### DIFF
--- a/src/otxlearner/data/__init__.py
+++ b/src/otxlearner/data/__init__.py
@@ -17,3 +17,23 @@ __all__ = [
     "TorchSplit",
     "torchify",
 ]
+
+from pathlib import Path
+from ..registries import register_dataset
+
+
+@register_dataset("ihdp")
+def get_ihdp(root: str | Path = Path.home() / ".cache/otxlearner/ihdp") -> IHDPDataset:
+    return load_ihdp(root)
+
+
+@register_dataset("twins")
+def get_twins(
+    root: str | Path = Path.home() / ".cache/otxlearner/twins",
+) -> TwinsDataset:
+    return load_twins(root)
+
+
+@register_dataset("acic")
+def get_acic(root: str | Path = Path.home() / ".cache/otxlearner/acic") -> ACICDataset:
+    return load_acic(root)

--- a/src/otxlearner/registries.py
+++ b/src/otxlearner/registries.py
@@ -1,1 +1,34 @@
-"""Module registries for datasets and trainers."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Dict, Type
+
+from .trainers.base import BaseTrainer
+
+_DATASETS: Dict[str, Callable[..., object]] = {}
+_TRAINERS: Dict[str, Type[BaseTrainer]] = {}
+
+
+def register_dataset(
+    name: str,
+) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    """Register a dataset loader by name."""
+
+    def decorator(fn: Callable[..., object]) -> Callable[..., object]:
+        _DATASETS[name] = fn
+        return fn
+
+    return decorator
+
+
+def register_trainer(name: str) -> Callable[[Type[BaseTrainer]], Type[BaseTrainer]]:
+    """Register a trainer class by name."""
+
+    def decorator(cls: Type[BaseTrainer]) -> Type[BaseTrainer]:
+        _TRAINERS[name] = cls
+        return cls
+
+    return decorator
+
+
+__all__ = ["_DATASETS", "_TRAINERS", "register_dataset", "register_trainer"]

--- a/src/otxlearner/trainers/dann.py
+++ b/src/otxlearner/trainers/dann.py
@@ -1,1 +1,87 @@
-"""Domain-adversarial trainer."""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from ..models import MLPEncoder, GradientReversal, DomainDiscriminator
+from ..schedulers import cosine_warmup_lambda
+from .base import BaseTrainer
+from ..registries import register_trainer
+
+
+@register_trainer("dann")
+class DANNTrainer(BaseTrainer):
+    """Domain-adversarial training using gradient reversal."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        *,
+        hidden_sizes: list[int] | None = None,
+        hidden_dim: int = 64,
+        lr: float = 1e-3,
+        lambda_max: float = 1.0,
+        epochs: int = 5,
+        device: str | torch.device = "cpu",
+    ) -> None:
+        model = MLPEncoder(input_dim, hidden_sizes=hidden_sizes)
+        super().__init__(model, device=device)
+        self.grl = GradientReversal()
+        assert isinstance(self.model, MLPEncoder)
+        feat_dim = self.model.tau_head.in_features
+        self.discriminator = DomainDiscriminator(feat_dim, hidden_dim=hidden_dim)
+        params = list(self.model.parameters()) + list(self.discriminator.parameters())
+        self.optimizer = torch.optim.Adam(params, lr=lr)
+        self.lambda_schedule = cosine_warmup_lambda(lambda_max, epochs)
+
+    def training_step(
+        self, batch: tuple[torch.Tensor, ...], epoch: int, lam: float
+    ) -> torch.Tensor:
+        x, t, yf, mu0, mu1, e = batch
+        x, t, yf, mu0, mu1, e = (
+            x.to(self.device),
+            t.to(self.device),
+            yf.to(self.device),
+            mu0.to(self.device),
+            mu1.to(self.device),
+            e.to(self.device),
+        )
+        assert isinstance(self.model, MLPEncoder)
+        feats = self.model.net(x)
+        outcome = self.model.outcome_head(feats).squeeze(-1)
+        tau = self.model.tau_head(feats).squeeze(-1)
+        y_pred = outcome + t * tau
+        factual_loss = nn.functional.mse_loss(y_pred, yf)
+        mu1_hat = outcome + tau
+        d_hat = t * (yf - outcome) / e + (1 - t) * (mu1_hat - yf) / (1 - e)
+        tau_loss = nn.functional.mse_loss(tau, d_hat)
+        dom_pred = self.discriminator(self.grl(feats, lam))
+        bal_loss = nn.functional.cross_entropy(dom_pred, t.long())
+        loss: torch.Tensor = factual_loss + tau_loss + bal_loss
+        return loss
+
+    def validation_step(
+        self, batch: tuple[torch.Tensor, ...], epoch: int
+    ) -> tuple[float, float]:
+        x, t, yf, mu0, mu1, e = batch
+        x, t, yf, mu0, mu1, e = (
+            x.to(self.device),
+            t.to(self.device),
+            yf.to(self.device),
+            mu0.to(self.device),
+            mu1.to(self.device),
+            e.to(self.device),
+        )
+        assert isinstance(self.model, MLPEncoder)
+        feats = self.model.net(x)
+        tau = self.model.tau_head(feats).squeeze(-1)
+        outcome = self.model.outcome_head(feats).squeeze(-1)
+        mu1_hat = outcome + tau
+        d_hat = t * (yf - outcome) / e + (1 - t) * (mu1_hat - yf) / (1 - e)
+        mse = nn.functional.mse_loss(tau, d_hat, reduction="sum").item()
+        dom_pred = self.discriminator(feats)
+        bal = nn.functional.cross_entropy(dom_pred, t.long(), reduction="sum").item()
+        return mse, bal
+
+
+__all__ = ["DANNTrainer"]

--- a/src/otxlearner/trainers/sinkhorn.py
+++ b/src/otxlearner/trainers/sinkhorn.py
@@ -1,1 +1,94 @@
-"""Sinkhorn trainer implementation."""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from ..models import MLPEncoder, Sinkhorn, UnbalancedSinkhorn
+from ..schedulers import cosine_warmup_lambda
+from .base import BaseTrainer
+from ..registries import register_trainer
+
+
+@register_trainer("sinkhorn")
+class SinkhornTrainer(BaseTrainer):
+    """Trainer using Sinkhorn divergence for balancing."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        *,
+        hidden_sizes: list[int] | None = None,
+        lr: float = 1e-3,
+        lambda_max: float = 1.0,
+        epsilon: float = 0.05,
+        unbalanced: bool = False,
+        epochs: int = 5,
+        device: str | torch.device = "cpu",
+    ) -> None:
+        model = MLPEncoder(input_dim, hidden_sizes=hidden_sizes)
+        super().__init__(model, device=device)
+        self.div = (
+            UnbalancedSinkhorn(blur=epsilon) if unbalanced else Sinkhorn(blur=epsilon)
+        )
+        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=lr)
+        self.lambda_schedule = cosine_warmup_lambda(lambda_max, epochs)
+
+    def training_step(
+        self, batch: tuple[torch.Tensor, ...], epoch: int, lam: float
+    ) -> torch.Tensor:
+        x, t, yf, mu0, mu1, e = batch
+        x, t, yf, mu0, mu1, e = (
+            x.to(self.device),
+            t.to(self.device),
+            yf.to(self.device),
+            mu0.to(self.device),
+            mu1.to(self.device),
+            e.to(self.device),
+        )
+        assert isinstance(self.model, MLPEncoder)
+        feats = self.model.net(x)
+        outcome = self.model.outcome_head(feats).squeeze(-1)
+        tau = self.model.tau_head(feats).squeeze(-1)
+        y_pred = outcome + t * tau
+        factual_loss = nn.functional.mse_loss(y_pred, yf)
+        mu1_hat = outcome + tau
+        d_hat = t * (yf - outcome) / e + (1 - t) * (mu1_hat - yf) / (1 - e)
+        tau_loss = nn.functional.mse_loss(tau, d_hat)
+        feats_t = feats[t.bool()]
+        feats_c = feats[~t.bool()]
+        if len(feats_t) > 0 and len(feats_c) > 0:
+            bal_loss: torch.Tensor = self.div(feats_t, feats_c)
+        else:
+            bal_loss = torch.tensor(0.0, device=self.device)
+        loss: torch.Tensor = factual_loss + tau_loss + lam * bal_loss
+        return loss
+
+    def validation_step(
+        self, batch: tuple[torch.Tensor, ...], epoch: int
+    ) -> tuple[float, float]:
+        x, t, yf, mu0, mu1, e = batch
+        x, t, yf, mu0, mu1, e = (
+            x.to(self.device),
+            t.to(self.device),
+            yf.to(self.device),
+            mu0.to(self.device),
+            mu1.to(self.device),
+            e.to(self.device),
+        )
+        assert isinstance(self.model, MLPEncoder)
+        feats = self.model.net(x)
+        tau = self.model.tau_head(feats).squeeze(-1)
+        outcome = self.model.outcome_head(feats).squeeze(-1)
+        mu1_hat = outcome + tau
+        d_hat = t * (yf - outcome) / e + (1 - t) * (mu1_hat - yf) / (1 - e)
+        mse = nn.functional.mse_loss(tau, d_hat, reduction="sum").item()
+        feats_t = feats[t.bool()]
+        feats_c = feats[~t.bool()]
+        if len(feats_t) > 0 and len(feats_c) > 0:
+            bal = self.div(feats_t, feats_c).item() * x.size(0)
+        else:
+            bal = 0.0
+        return mse, bal
+
+
+__all__ = ["SinkhornTrainer"]

--- a/tests/test_base_trainer.py
+++ b/tests/test_base_trainer.py
@@ -1,0 +1,37 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from otxlearner.trainers.base import BaseTrainer
+
+
+class ToyTrainer(BaseTrainer):
+    def __init__(self) -> None:
+        super().__init__(torch.nn.Linear(1, 1))
+        self.optimizer = torch.optim.SGD(self.model.parameters(), lr=0.1)
+        self.lambda_schedule = lambda epoch: 0.0
+
+    def training_step(
+        self, batch: tuple[torch.Tensor, ...], epoch: int, lam: float
+    ) -> torch.Tensor:
+        x, y = batch
+        pred = self.model(x)
+        loss = torch.nn.functional.mse_loss(pred, y)
+        return loss
+
+    def validation_step(
+        self, batch: tuple[torch.Tensor, ...], epoch: int
+    ) -> tuple[float, float]:
+        x, y = batch
+        pred = self.model(x)
+        mse = torch.nn.functional.mse_loss(pred, y, reduction="sum")
+        return float(mse), 0.0
+
+
+def test_base_trainer_early_stop() -> None:
+    data = torch.randn(10, 1)
+    targets = torch.randn(10, 1)
+    ds = TensorDataset(data, targets)
+    loader = DataLoader(ds, batch_size=5)
+    trainer = ToyTrainer()
+    history = trainer.fit(loader, loader, epochs=5, early_stop=2)
+    assert 1 <= len(history) <= 5

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,0 +1,10 @@
+from otxlearner.registries import _DATASETS, _TRAINERS
+from otxlearner.trainers.sinkhorn import SinkhornTrainer
+from otxlearner.trainers.dann import DANNTrainer
+
+
+def test_registries_populated() -> None:
+    assert "ihdp" in _DATASETS
+    assert "sinkhorn" in _TRAINERS
+    assert _TRAINERS["sinkhorn"] is SinkhornTrainer
+    assert _TRAINERS["dann"] is DANNTrainer

--- a/tests/test_sinkhorn_trainer.py
+++ b/tests/test_sinkhorn_trainer.py
@@ -1,0 +1,20 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from otxlearner.trainers.sinkhorn import SinkhornTrainer
+
+
+def test_sinkhorn_trainer_overfit() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(4, 2)
+    t = torch.randint(0, 2, (4,)).float()
+    yf = torch.randn(4)
+    mu0 = torch.zeros_like(yf)
+    mu1 = torch.zeros_like(yf)
+    e = torch.full_like(yf, 0.5)
+    ds = TensorDataset(x, t, yf, mu0, mu1, e)
+    loader = DataLoader(ds, batch_size=4)
+    trainer = SinkhornTrainer(input_dim=2, lambda_max=0.0, epochs=1)
+    trainer.div = lambda a, b: torch.tensor(0.0)
+    history = trainer.fit(loader, loader, epochs=1, early_stop=1)
+    assert len(history) >= 1


### PR DESCRIPTION
## Summary
- introduce dataset/trainer registries
- register IHDP/Twins/ACIC loaders
- implement `SinkhornTrainer` and `DANNTrainer`

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b488ede48324ba1a2873cd6f374e