### PR TITLE
Refine AMP handling

### DIFF
--- a/scratchpad.md
+++ b/scratchpad.md
@@ -2,3 +2,4 @@
 
 - Added project skeleton and pre-commit hooks.
 - Documented IHDP quick start and added demo notebook.
+- Updated BaseTrainer to avoid AMP warnings.


### PR DESCRIPTION
## Summary
- use `torch.autocast` in `BaseTrainer`
- disable GradScaler when CUDA is unavailable
- note the change in `scratchpad`

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`
- `pytest --cov=src -q`

------
https://chatgpt.com/codex/tasks/task_e_6865dc71c3c083249f7ac25bd7fc4a5d