### PR TITLE
Fix CLI usage in quick start

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -8,7 +8,7 @@ python -m pip install -r requirements.txt
 python -m pip install -e .
 
 # train for a few epochs and log metrics
-python -m otxlearner.train --epochs 5 --log-dir runs/ihdp
+python -m otxlearner.train ihdp sinkhorn --epochs 5 --log-dir runs/ihdp
 ```
 
 See the `notebooks/training_curves.ipynb` notebook for visualising TensorBoard logs.


### PR DESCRIPTION
## Summary
- update quick start guide for the modular CLI

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ef6e1f14832487dcb9f5a6ebd67c