### PR TITLE
fix CLI trainer registration

### DIFF
--- a/src/otxlearner/cli.py
+++ b/src/otxlearner/cli.py
@@ -8,6 +8,10 @@ import inspect
 from typing import Any, Callable, cast
 import numpy as np
 
+# ensure dataset and trainer registries are populated
+from . import data  # noqa: F401
+from .trainers import dann, sinkhorn  # noqa: F401
+
 from .registries import _DATASETS, _TRAINERS
 from .trainers.base import BaseTrainer
 from .data.types import DatasetProtocol


### PR DESCRIPTION
## Summary
- ensure dataset and trainer registries are loaded so the CLI works

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -vv`
- `mkdocs build -s`


------
https://chatgpt.com/codex/tasks/task_e_6865f370d8ac83249167d50ef234d367