### PR TITLE
Fix nondeterministic loss test

### DIFF
--- a/tests/test_one_epoch.py
+++ b/tests/test_one_epoch.py
@@ -7,6 +7,7 @@ from otxlearner.models import MLPEncoder
 
 
 def test_one_epoch_loss_decreases() -> None:
+    torch.manual_seed(0)
     g = torch.Generator().manual_seed(0)
     n = 256
     x = torch.randn(n, 10, generator=g)


### PR DESCRIPTION
## Summary
- seed torch before building the model in `test_one_epoch_loss_decreases`

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_68684fbdea608324a2c0a1483b225fd5