### PR TITLE
Optimize CUDA CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
       IHDP_DATA: /github/home/.cache/otxlearner/ihdp
     steps:
       - uses: actions/checkout@v4
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
       - uses: actions/cache@v3
         with:
           path: ~/.cache/uv
@@ -79,7 +77,6 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system .[dev]
-          uv pip install --system torch --index-url https://download.pytorch.org/whl/cu118
           pip install -e .
       - name: Prepare dataset
         run: |


### PR DESCRIPTION
## Summary
- speed up CUDA workflow
- rely on PyTorch image's built-in torch and skip pip upgrade

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_68685a4055748324bc3afcb9bf2ed59a