### PR TITLE
Add predict_tau helpers with type hints

### DIFF
--- a/src/otxlearner/models/flow.py
+++ b/src/otxlearner/models/flow.py
@@ -91,6 +91,11 @@ class FlowEncoder(nn.Module):
         tau = self.tau_head(feats).squeeze(-1)
         return outcome, tau
 
+    def predict_tau(self, x: torch.Tensor) -> torch.Tensor:
+        """Return treatment effect predictions for ``x``."""
+        _outcome, tau = self.forward(x)
+        return tau
+
     def inverse(
         self, z: torch.Tensor
     ) -> torch.Tensor:  # pragma: no cover - simple inverse

--- a/src/otxlearner/models/mlp.py
+++ b/src/otxlearner/models/mlp.py
@@ -30,5 +30,10 @@ class MLPEncoder(nn.Module):
         tau = self.tau_head(feats).squeeze(-1)
         return outcome, tau
 
+    def predict_tau(self, x: torch.Tensor) -> torch.Tensor:
+        """Return treatment effect predictions for ``x``."""
+        _outcome, tau = self.forward(x)
+        return tau
+
 
 __all__ = ["MLPEncoder"]

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -12,6 +12,14 @@ def test_flow_encoder_shapes() -> None:
     assert tau.shape == (2,)
 
 
+def test_flow_predict_tau() -> None:
+    model = FlowEncoder(3)
+    x = torch.randn(2, 3)
+    _, tau = model(x)
+    pred = model.predict_tau(x)
+    assert torch.allclose(tau, pred)
+
+
 def test_realnvp_inverse() -> None:
     flow = RealNVP(4, n_flows=2)
     x = torch.randn(3, 4)

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -12,3 +12,11 @@ def test_mlp_encoder_shapes() -> None:
     outcome, tau = model(x)
     assert outcome.shape == (batch_size,)
     assert tau.shape == (batch_size,)
+
+
+def test_mlp_predict_tau() -> None:
+    model = MLPEncoder(3)
+    x = torch.randn(2, 3)
+    direct = model(x)[1]
+    pred = model.predict_tau(x)
+    assert torch.allclose(direct, pred)


### PR DESCRIPTION
## Summary
- add `predict_tau` helper on MLPEncoder and FlowEncoder
- test new helpers

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_686860e8332c8324a15e124f6d539697