### PR TITLE
Add generic tabular loader

### DIFF
--- a/src/otxlearner/data/__init__.py
+++ b/src/otxlearner/data/__init__.py
@@ -2,6 +2,7 @@ from .ihdp import IHDPDataset, IHDPSplit, load_ihdp
 from .twins import TwinsDataset, TwinsSplit, load_twins
 from .acic import ACICDataset, ACICSplit, load_acic
 from .criteo import CriteoDataset, CriteoSplit, load_criteo_uplift
+from .tabular import TabularDataset, TabularSplit, load_tabular
 from .torch_adapter import TorchIHDP, TorchSplit, torchify
 
 __all__ = [
@@ -17,6 +18,9 @@ __all__ = [
     "CriteoDataset",
     "CriteoSplit",
     "load_criteo_uplift",
+    "TabularDataset",
+    "TabularSplit",
+    "load_tabular",
     "TorchIHDP",
     "TorchSplit",
     "torchify",

--- a/src/otxlearner/data/tabular.py
+++ b/src/otxlearner/data/tabular.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+__all__ = ["TabularSplit", "TabularDataset", "load_tabular"]
+
+
+@dataclass
+class TabularSplit:
+    x: npt.NDArray[np.float64]
+    t: npt.NDArray[np.float64]
+    yf: npt.NDArray[np.float64]
+    mu0: npt.NDArray[np.float64]
+    mu1: npt.NDArray[np.float64]
+
+
+@dataclass
+class TabularDataset:
+    train: TabularSplit
+    val: TabularSplit
+    test: TabularSplit
+
+
+def load_tabular(
+    data: str | Path | pd.DataFrame,
+    *,
+    features: Sequence[str],
+    treatment: str,
+    outcome: str,
+    val_fraction: float = 0.1,
+    test_fraction: float = 0.1,
+    seed: int = 42,
+) -> TabularDataset:
+    """Create train/val/test splits from a CSV file or DataFrame."""
+
+    if isinstance(data, (str, Path)):
+        df = pd.read_csv(data)
+    else:
+        df = data
+
+    x = df.loc[:, list(features)].to_numpy(dtype=np.float64)
+    t = df.loc[:, treatment].to_numpy(dtype=np.float64)
+    y = df.loc[:, outcome].to_numpy(dtype=np.float64)
+    mu0 = y.copy()
+    mu1 = y.copy()
+
+    rng = np.random.default_rng(seed)
+    idx = np.arange(len(df))
+    rng.shuffle(idx)
+
+    val_size = int(len(idx) * val_fraction)
+    test_size = int(len(idx) * test_fraction)
+    train_idx = idx[: -val_size - test_size]
+    val_idx = idx[-val_size - test_size : -test_size]
+    test_idx = idx[-test_size:]
+
+    def split(i: npt.NDArray[np.int_]) -> TabularSplit:
+        return TabularSplit(x=x[i], t=t[i], yf=y[i], mu0=mu0[i], mu1=mu1[i])
+
+    train = split(train_idx)
+    val = split(val_idx)
+    test = split(test_idx)
+    return TabularDataset(train=train, val=val, test=test)

--- a/tests/test_tabular_loader.py
+++ b/tests/test_tabular_loader.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+from otxlearner.data import load_tabular
+
+
+def _create_df(n: int = 50, d: int = 3) -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    data = {f"f{i}": rng.normal(size=n) for i in range(d)}
+    data["t"] = rng.integers(0, 2, size=n)
+    data["y"] = rng.normal(size=n)
+    return pd.DataFrame(data)
+
+
+def test_load_tabular_dataframe_deterministic() -> None:
+    df = _create_df()
+    ds1 = load_tabular(
+        df,
+        features=["f0", "f1", "f2"],
+        treatment="t",
+        outcome="y",
+        val_fraction=0.2,
+        test_fraction=0.1,
+        seed=0,
+    )
+    ds2 = load_tabular(
+        df,
+        features=["f0", "f1", "f2"],
+        treatment="t",
+        outcome="y",
+        val_fraction=0.2,
+        test_fraction=0.1,
+        seed=0,
+    )
+    assert np.array_equal(ds1.train.x, ds2.train.x)
+    assert np.array_equal(ds1.val.x, ds2.val.x)
+    assert np.array_equal(ds1.test.x, ds2.test.x)
+
+
+def test_load_tabular_csv(tmp_path: Path) -> None:
+    df = _create_df()
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+    ds = load_tabular(
+        csv_path,
+        features=["f0", "f1", "f2"],
+        treatment="t",
+        outcome="y",
+        val_fraction=0.2,
+        test_fraction=0.1,
+        seed=1,
+    )
+    n = len(df)
+    val_size = int(n * 0.2)
+    test_size = int(n * 0.1)
+    train_size = n - val_size - test_size
+    assert ds.train.x.shape == (train_size, 3)
+    assert ds.val.x.shape == (val_size, 3)
+    assert ds.test.x.shape == (test_size, 3)


### PR DESCRIPTION
## Summary
- add `tabular.py` with a generic CSV/DataFrame loader
- expose `load_tabular` in the data package
- test loading from DataFrame and CSV

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686b8558448324839a19801b1bd1f5