### PR TITLE
Fix pandas missing in CUDA job

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pandas-stubs",
+    "pandas",
 ]
 bench = [
     "tensorboard",


### PR DESCRIPTION
## Summary
- ensure pandas is installed by adding it to dev extras

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_686872c01318832483a8695b796c4416